### PR TITLE
Add Extra Installation Instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,13 @@
 ## Prerequisites
 Before deploying the application, ensure the following are installed:
 
-1. **Node.js and npm**\
-Download and install from [Node.js official site](https://nodejs.org/en/download/package-manager). npm is included with Node.js.\
+## 1. **Node.js and npm**
+You can download and install from [Node.js official site](https://nodejs.org/en/download/package-manager). `npm` is included with Node.js. Alternatively, you can install both `node` and `npm` with `apt` if you're installing `chat-less` on a Linux system:
+
+```bash
+sudo apt install nodejs
+```
+
 Verify installation in your command line/powershell/bash terminal, etc. Or don't, I'm not a cop:
 
 ```bash
@@ -16,25 +21,61 @@ node -v
 npm -v
 ```
 
-2. **Git**\
-Download and install from [Git official site](https://git-scm.com/downloads).\
+## 2. **Git**
+Download and install from the [Git official site](https://git-scm.com/downloads).\
 Verify installation in your command line/powershell/bash terminal, etc. Again, not a cop:
 ```bash
 git --version
 ```
 
-3. **MongoDB**\
-Create a free MongoDB cluster at MongoDB Atlas or set up MongoDB locally by downloading it from MongoDB Downloads.\
-Ensure you have connection credentials ready (username, password, and cluster URL). For MongoDB Atlas, refer to their Getting Started Guide.
+## 3. **MongoDB**
+For the database, you can either create a free MongoDB cluster on [MongoDB Atlas](https://www.mongodb.com/products/platform/atlas-database), or you can install MongoDB locally. 
+
+### Atlas
+
+MongoDB Atlas lets you get up and running relatively quickly. Simply head over to [Atlas](https://www.mongodb.com/products/platform/atlas-database), create an account, and create your cluster. Select the free teir, and choose your desired cluster name and location. 
+
+When prompted to choose a connection, select `Drivers` and ensure that your configuration has the following options:
+
+- Driver: `Node.js`
+- Version:`6.7 or later`
+
+Leave this screen open until your cluster has finished provisioning. Once this process has completed, you'll be given your connection string (which will begin with `mongodb+srv://`). This will contain your database username, password, and cluster URL that you will need for your `.env` file. 
+
+### Local
+
+Installing MongoDB locally is easiest on a Linux system. Below are a couple of guides that can help you get it up and running. 
+
+- [Digital Ocean - How To Install MongoDB on Ubuntu 20.04](https://www.digitalocean.com/community/tutorials/how-to-install-mongodb-on-ubuntu-20-04)
+- [AskUbuntu - MongoDB depends on libssl1.1 but it is not installable](https://askubuntu.com/questions/1403619/mongodb-install-fails-on-ubuntu-22-04-depends-on-libssl1-1-but-it-is-not-insta)
+
+Ensure you have connection credentials ready (username, password, and cluster URL)
 
 ## Deployment Instructions
 
-1. **Create the Database and Collection**
+### 1. **Create the Database and Collection**
   - Create a database called `YAP_LESS`.
   - Create a collection within the database called `YPL_MESSAGE`.
   - Alternatively, you can name them whatever you want and you can just update the names in the files prefixed with `mongodb-`. Or you can keep this simple with my repo, up to you. No, no, go on, make your own names. I won't judge. I'm just a file.
 
-1. **Clone the Repository**\
+#### 1.1 **Atlas**
+
+If you chose to use Atlas, you can use the web GUI to create your database and collection. 
+
+#### 1.2 **Local**
+
+If you chose to host the database locally, you can use these commands to create a new database and collection (assuming MongoDB is installed and running):
+
+```bash
+# connect to local mongodb
+mongo
+
+# create new database & collection
+use YAP_LESS
+db.createCollection("YPL_MESSAGE", {capped: false});
+```
+
+### 2. **Clone the `chat-less` Repository**
 Open your terminal and run:
 Alternatively, just use github's GUI to clone the repo. There's a big green `<> Code` button on this page you can click.
 I do recommend opening the chat-less folder in your terminal though.
@@ -43,9 +84,9 @@ git clone https://github.com/RigidSeine/chat-less.git
 cd chat-less
 ```
 
-2. **Setup the Server**
+### 3. **Setup the Server**
 
-  - Navigate to the server folder:
+  - Navigate to the `server` folder:
 
   ```bash
   cd server
@@ -67,8 +108,8 @@ MDB_PW=<your_password>
 MDB_CLUSTER_NAME=<your_cluster>
 ```
 
-3. **Setup the Client**
-  - Open a **new terminal (important!)** and navigate to the client folder:
+### 4. **Setup the Client**
+  - Open a **new terminal (important!)** and navigate to the `client` folder:
   ```bash
   cd ../client
   ```
@@ -83,9 +124,9 @@ MDB_CLUSTER_NAME=<your_cluster>
   npm run dev
   ```
 
-4. **Access the Application**
+### 5. **Access the Application**
   - Open http://localhost:5173 in your browser.
   - Type away.
 
-5. **Delete System32**
+### 6. **Delete System32**
   - I'm kidding. Don't actually do that.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ cd chat-less
   cd server
   ```
 
-  - Install dependencies (very important!!):
+  - Install dependencies ***(very important!!)***:
 
 ```bash
 npm install
@@ -109,7 +109,7 @@ MDB_CLUSTER_NAME=<your_cluster>
 ```
 
 ### 4. **Setup the Client**
-  - Open a **new terminal (important!)** and navigate to the `client` folder:
+  - Open a ***new terminal (important!)*** and navigate to the `client` folder:
   ```bash
   cd ../client
   ```


### PR DESCRIPTION
This PR adds some extra installation instructions to the `README` that describe (most of) the steps required for setting up the project and using either a locally hosted DB or a cluster hosted by MongoDB. There is still some ambiguity left, please see issue #1. 